### PR TITLE
add name_with_middle element for russian locale

### DIFF
--- a/library/src/main/assets/locales/ru.yml
+++ b/library/src/main/assets/locales/ru.yml
@@ -42,6 +42,9 @@ ru:
         - "#{female_last_name} #{female_first_name}"
         - "#{female_first_name} #{female_middle_name} #{female_last_name}"
         - "#{female_last_name} #{female_first_name} #{female_middle_name}"
+      name_with_middle:
+        - "#{male_last_name} #{male_first_name} #{male_middle_name}"
+        - "#{female_last_name} #{female_first_name} #{female_middle_name}"
 
     phone_number:
       formats: ['+7(9##)###-##-##']


### PR DESCRIPTION
calling nameWithMiddle() with russian locale causes TypeCast Exception. I've added "name_with_middle" to the "ru.yml" file.