### PR TITLE
Add jitpack repository to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ Download
 
 You can use either Maven:
 ```xml
+<repositories>
+  <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+  </repository>
+</repositories>
+
 <dependency>
   <groupId>com.github.moove-it</groupId>
   <artifactId>fakeit</artifactId>


### PR DESCRIPTION
Add jitpack repository to download section on readme.
According jitpack: https://jitpack.io/#moove-it/fakeit/v0.5